### PR TITLE
Fix: wrong detection of html text encoding

### DIFF
--- a/deadseeker/loggingresponsehandler.py
+++ b/deadseeker/loggingresponsehandler.py
@@ -18,5 +18,6 @@ class LoggingUrlFetchResponseHandler(UrlFetchResponseHandler):
             else:
                 logger.error(
                     f'::error ::{errortype}: {str(error)} - {url}')
+            logger.debug("The following exception occured", exc_info=error)
         else:
             logger.info(f'{status} - {url} - {elapsedstr}')

--- a/deadseeker/responsefetcher.py
+++ b/deadseeker/responsefetcher.py
@@ -68,7 +68,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
             timer.stop()
             resp.status = response.status
             if has_html(response) and is_onsite(urltarget):
-                resp.html = await response.text()
+                resp.html = await response.text(encoding="utf-8")
 
 
 def has_html(response: ClientResponse) -> bool:

--- a/test/test_loggingresponsehandler.py
+++ b/test/test_loggingresponsehandler.py
@@ -30,21 +30,29 @@ class TestLoggingResponseHandler(unittest.TestCase):
         self.resp.status = 400
         self.resp.error = ClientError()
         with patch.object(self.logger, 'error') as error_mock,\
-                patch.object(self.logger, 'info') as info_mock:
+                patch.object(self.logger, 'info') as info_mock,\
+                patch.object(self.logger, 'debug') as debug_mock:
             self.testobj.handle_response(self.resp)
-            expected = '::error ::ClientError: 400' +\
+            expected_error = '::error ::ClientError: 400' +\
                 ' - http://testing.test.com/'
-            error_mock.assert_called_with(expected)
+            expected_debug = 'The following exception occured'
+            error_mock.assert_called_with(expected_error)
+            debug_mock.assert_called_with(expected_debug,
+                                          exc_info=self.resp.error)
             info_mock.assert_not_called()
 
     def test_error_logs_when_no_status_error(self):
         self.resp.error = ClientError('test error')
         with patch.object(self.logger, 'error') as error_mock,\
-                patch.object(self.logger, 'info') as info_mock:
+                patch.object(self.logger, 'info') as info_mock,\
+                patch.object(self.logger, 'debug') as debug_mock:
             self.testobj.handle_response(self.resp)
             expected = '::error ::ClientError: test error' +\
                 ' - http://testing.test.com/'
+            expected_debug = 'The following exception occured'
             error_mock.assert_called_with(expected)
+            debug_mock.assert_called_with(expected_debug,
+                                          exc_info=self.resp.error)
             info_mock.assert_not_called()
 
 


### PR DESCRIPTION
By default the aiohttp client tried to autodetect the used encoding. If the encoding was not provided through the `Content-Type` header (e.g., `Content-Type: text/html; charset=UTF-8`) the client tried to guess it by looking at the requests text body. 

This issue was discovered in: https://github.com/ScholliYT/Broken-Links-Crawler-Action/issues/16