### PR TITLE
Feature/upgrade aiohttp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,9 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.812'
+    rev: 'v0.971'
     hooks:
     -   id: mypy
         files: ^deadseeker/  
         args: [--disallow-untyped-defs]
+        additional_dependencies: [aiohttp-retry==2.8.3]

--- a/deadseeker/clientsession.py
+++ b/deadseeker/clientsession.py
@@ -46,10 +46,10 @@ class DefaultClientSessionFactory(ClientSessionFactory):
         retry_options = ExponentialRetry(
                             attempts=config.max_tries,
                             max_timeout=config.max_time,
-                            exceptions=[
+                            exceptions={
                                 aiohttp.ClientError,
                                 asyncio.TimeoutError
-                            ])
+                            })
         return RetryClient(
                 raise_for_status=True,
                 connector=connector,

--- a/deadseeker/clientsession.py
+++ b/deadseeker/clientsession.py
@@ -4,13 +4,13 @@ import asyncio
 import logging
 from types import SimpleNamespace
 from aiohttp import (
-    ClientSession,
     TraceConfig,
     TraceRequestStartParams,
     TCPConnector,
     ClientTimeout
 )
-from aiohttp_retry import RetryClient, ExponentialRetry  # type: ignore
+from aiohttp_retry import RetryClient, ExponentialRetry
+from aiohttp_retry.types import ClientType
 from abc import abstractmethod, ABC
 
 logger = logging.getLogger(__name__)
@@ -18,15 +18,15 @@ logger = logging.getLogger(__name__)
 
 class ClientSessionFactory(ABC):
     @abstractmethod  # pragma: no mutate
-    def get_client_session(self, config: SeekerConfig) -> ClientSession:
+    def get_client_session(self, config: SeekerConfig) -> ClientType:
         pass
 
 
 class DefaultClientSessionFactory(ClientSessionFactory):
 
-    def get_client_session(self, config: SeekerConfig) -> ClientSession:
+    def get_client_session(self, config: SeekerConfig) -> ClientType:
         async def _on_request_start(
-            session: ClientSession,
+            session: ClientType,
             trace_config_ctx: SimpleNamespace,
             params: TraceRequestStartParams
         ) -> None:

--- a/deadseeker/loggingresponsehandler.py
+++ b/deadseeker/loggingresponsehandler.py
@@ -18,5 +18,6 @@ class LoggingUrlFetchResponseHandler(UrlFetchResponseHandler):
             else:
                 logger.error(
                     f'::error ::{errortype}: {str(error)} - {url}')
+            logger.debug("The following exception occured", exc_info=error)
         else:
             logger.info(f'{status} - {url} - {elapsedstr}')

--- a/deadseeker/responsefetcher.py
+++ b/deadseeker/responsefetcher.py
@@ -1,5 +1,6 @@
 from .common import UrlFetchResponse, UrlTarget, SeekerConfig
-from aiohttp import ClientSession, ClientResponse
+from aiohttp import ClientResponse
+from aiohttp_retry.types import ClientType
 from abc import abstractmethod, ABC
 from .timer import Timer
 import aiohttp
@@ -8,7 +9,7 @@ import aiohttp
 class ResponseFetcher:
     async def fetch_response(
             self,
-            session: ClientSession,
+            session: ClientType,
             urltarget: UrlTarget) -> UrlFetchResponse:
         pass
 
@@ -34,7 +35,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
 
     async def fetch_response(
             self,
-            session: ClientSession,
+            session: ClientType,
             urltarget: UrlTarget) -> UrlFetchResponse:
         resp = UrlFetchResponse(urltarget)
         timer = Timer()
@@ -51,7 +52,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
     @abstractmethod  # pragma: no mutate
     async def _inner_fetch(
             self,
-            session: ClientSession,
+            session: ClientType,
             resp: UrlFetchResponse,
             urltarget: UrlTarget,
             timer: Timer) -> None:
@@ -59,7 +60,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
 
     async def _do_get(
             self,
-            session: ClientSession,
+            session: ClientType,
             resp: UrlFetchResponse,
             urltarget: UrlTarget,
             timer: Timer) -> None:
@@ -86,7 +87,7 @@ class HeadThenGetIfHtmlResponseFetcher(AbstractResponseFetcher):
 
     async def _inner_fetch(
             self,
-            session: ClientSession,
+            session: ClientType,
             resp: UrlFetchResponse,
             urltarget: UrlTarget,
             timer: Timer) -> None:
@@ -110,7 +111,7 @@ class AlwaysGetIfOnSiteResponseFetcher(HeadThenGetIfHtmlResponseFetcher):
 
     async def _inner_fetch(
             self,
-            session: ClientSession,
+            session: ClientType,
             resp: UrlFetchResponse,
             urltarget: UrlTarget,
             timer: Timer) -> None:

--- a/deadseeker/responsefetcher.py
+++ b/deadseeker/responsefetcher.py
@@ -68,7 +68,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
             timer.stop()
             resp.status = response.status
             if has_html(response) and is_onsite(urltarget):
-                resp.html = await response.text(encoding="utf-8")
+                resp.html = await response.text()
 
 
 def has_html(response: ClientResponse) -> bool:

--- a/deadseeker/responsefetcher.py
+++ b/deadseeker/responsefetcher.py
@@ -68,7 +68,7 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
             timer.stop()
             resp.status = response.status
             if has_html(response) and is_onsite(urltarget):
-                resp.html = await response.text()
+                resp.html = await response.text(encoding="utf-8")
 
 
 def has_html(response: ClientResponse) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 validators==0.18.2
-aiohttp==3.7.4.post0
-aiodns==2.0.0
-aiohttp-retry==2.3.5
+aiohttp==3.8.1
+aiodns==3.0.0
+aiohttp-retry==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 validators==0.18.2
 aiohttp==3.8.1
 aiodns==3.0.0
-aiohttp-retry==2.5.1
+aiohttp-retry==2.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ max_complexity=10
 statistics=True
 
 [tool:pytest]
+asyncio_mode = auto
 markers=
     integrationtest: mark test as an integration test
     asyncio: asynchronous tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,8 +3,8 @@ flake8==3.9.0
 pytest==6.2.2
 pytest-cov==2.11.1
 pre-commit==2.11.1
-pytest-aiohttp==0.3.0
-mypy==0.812
-aiounittest==1.4.0
-aioresponses==0.7.2
+pytest-aiohttp==1.0.4
+mypy==0.961
+aiounittest==1.4.2
+aioresponses==0.7.3
 mutmut==2.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ pytest==6.2.2
 pytest-cov==2.11.1
 pre-commit==2.11.1
 pytest-aiohttp==1.0.4
-mypy==0.961
+mypy==0.971
 aiounittest==1.4.2
 aioresponses==0.7.3
 mutmut==2.1.0

--- a/test/test_clientsession.py
+++ b/test/test_clientsession.py
@@ -6,7 +6,8 @@ from deadseeker.common import SeekerConfig
 import aiohttp
 import asyncio
 from types import SimpleNamespace
-from aiohttp import ClientSession, TraceRequestStartParams
+from aiohttp import TraceRequestStartParams
+from aiohttp_retry.types import ClientType
 import logging
 
 
@@ -65,10 +66,10 @@ class TestDefaultClientSessionFactory(AsyncTestCase):
         self.exponentialretry.assert_called_with(
                             attempts=self.config.max_tries,
                             max_timeout=self.config.max_time,
-                            exceptions=[
+                            exceptions={
                                 aiohttp.ClientError,
                                 asyncio.TimeoutError
-                            ])
+                            })
 
     async def test_traceconfig_configuration(self):
         self.testObj.get_client_session(
@@ -79,7 +80,7 @@ class TestDefaultClientSessionFactory(AsyncTestCase):
         append.assert_called_once()
         thecall = append.call_args_list[0]
         func = thecall.args[0]
-        session = Mock(spec=ClientSession)
+        session = Mock(spec=ClientType)
         trace_config_ctx = Mock(spec=SimpleNamespace)
         ctx = dict()
         trace_config_ctx.trace_request_ctx = ctx

--- a/test/test_deadseeker.py
+++ b/test/test_deadseeker.py
@@ -29,7 +29,8 @@ from deadseeker.linkparser import (
     LinkParser
 )
 from deadseeker.timer import Timer
-from aiohttp import ClientSession, ClientResponseError, ClientError
+from aiohttp import ClientResponseError, ClientError
+from aiohttp_retry.types import ClientType
 
 
 # Preparing test data to represent two web sites, test1.com and test2.com
@@ -212,7 +213,7 @@ class TestDeadSeeker(unittest.TestCase):
         self.testobj.responsefetcherfactory\
             .get_response_fetcher.return_value = self.responsefetcher
 
-        def fetch_response_mock(session: ClientSession, urltarget: UrlTarget):
+        def fetch_response_mock(session: ClientType, urltarget: UrlTarget):
             response_creator = TEST_RESPONSES_BY_URL.get(urltarget.url)
             self.assertIsNotNone(
                 response_creator,

--- a/test/test_loggingresponsehandler.py
+++ b/test/test_loggingresponsehandler.py
@@ -30,21 +30,29 @@ class TestLoggingResponseHandler(unittest.TestCase):
         self.resp.status = 400
         self.resp.error = ClientError()
         with patch.object(self.logger, 'error') as error_mock,\
-                patch.object(self.logger, 'info') as info_mock:
+                patch.object(self.logger, 'info') as info_mock,\
+                patch.object(self.logger, 'debug') as debug_mock:
             self.testobj.handle_response(self.resp)
-            expected = '::error ::ClientError: 400' +\
+            expected_error = '::error ::ClientError: 400' +\
                 ' - http://testing.test.com/'
-            error_mock.assert_called_with(expected)
+            expected_debug = 'The following exception occured'
+            error_mock.assert_called_with(expected_error)
+            debug_mock.assert_called_with(expected_debug,
+                                          exc_info=self.resp.error)
             info_mock.assert_not_called()
 
     def test_error_logs_when_no_status_error(self):
         self.resp.error = ClientError('test error')
         with patch.object(self.logger, 'error') as error_mock,\
-                patch.object(self.logger, 'info') as info_mock:
+                patch.object(self.logger, 'info') as info_mock,\
+                patch.object(self.logger, 'debug') as debug_mock:
             self.testobj.handle_response(self.resp)
             expected = '::error ::ClientError: test error' +\
                 ' - http://testing.test.com/'
+            expected_debug = 'The following exception occured'
             error_mock.assert_called_with(expected)
+            debug_mock.assert_called_with(expected_debug,
+                                          exc_info=self.resp.error)
             info_mock.assert_not_called()
 
 

--- a/test/test_responsefetcher.py
+++ b/test/test_responsefetcher.py
@@ -2,10 +2,10 @@ import unittest
 from aiounittest import AsyncTestCase
 from asyncio import TimeoutError
 from aiohttp import (
-    ClientSession,
     ClientResponseError,
     ClientError
 )
+from aiohttp_retry import RetryClient
 from unittest.mock import Mock, patch
 from aioresponses import aioresponses
 from deadseeker.common import SeekerConfig
@@ -57,7 +57,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     @aioresponses()
     async def test_if_same_site_and_html(self,  m):
         self._prep_request(m, TEST_HOME_URL, content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -75,7 +75,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             TEST_HOME_URL,
             headexception=exception,
             content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -93,7 +93,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             TEST_HOME_URL,
             headexception=exception,
             content_type=TYPE_JSON)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -111,7 +111,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             TEST_OTHER_URL,
             headexception=exception,
             content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -124,7 +124,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     async def test_if_other_site_and_html(
             self, m):
         self._prep_request(m, TEST_OTHER_URL, content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -137,7 +137,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     async def test_if_same_site_and_not_html(
             self,  m):
         self._prep_request(m, TEST_HOME_URL, content_type=TYPE_JSON)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -150,7 +150,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     async def test_if_other_site_and_not_html(
             self, m):
         self._prep_request(m, TEST_OTHER_URL, content_type=TYPE_JSON)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -164,7 +164,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             self, m):
         exception = ClientResponseError(None, None, status=404)
         self._prep_request(m, TEST_HOME_URL, headexception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -178,7 +178,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             self, m):
         exception = ClientError()
         self._prep_request(m, TEST_HOME_URL, headexception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -192,7 +192,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             self, m):
         exception = TimeoutError()
         self._prep_request(m, TEST_HOME_URL, headexception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -236,7 +236,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
     @aioresponses()
     async def test_if_same_site_and_html(self,  m):
         self._prep_request(m, TEST_HOME_URL, content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -250,7 +250,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
             self, m):
         self._prep_request(
             m, TEST_OTHER_URL, method='HEAD', content_type=TYPE_HTML)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -263,7 +263,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
     async def test_if_same_site_and_not_html(
             self,  m):
         self._prep_request(m, TEST_HOME_URL, content_type=TYPE_JSON)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -277,7 +277,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
             self, m):
         self._prep_request(
             m, TEST_OTHER_URL, method='HEAD', content_type=TYPE_JSON)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -291,7 +291,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
             self, m):
         exception = ClientResponseError(None, None, status=404)
         self._prep_request(m, TEST_HOME_URL, exception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -305,7 +305,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
             self, m):
         exception = ClientError()
         self._prep_request(m, TEST_HOME_URL, exception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
@@ -319,7 +319,7 @@ class TestAlwaysGetIfOnSiteResponseFetcher(AsyncTestCase):
             self, m):
         exception = TimeoutError()
         self._prep_request(m, TEST_HOME_URL, exception=exception)
-        async with ClientSession() as session:
+        async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)


### PR DESCRIPTION
Instead of defaulting to "utf-8" encoding as an #20, simply upgrading to Version >3.8.1 of aiohttp solves the UnicodeDecodeError too, as newer versions of aiohttp use another charset detection lib.