### PR TITLE
fix HeadThenGetIfHtmlResponseFetcher

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ count=True
 show_source=True
 max_complexity=10
 statistics=True
+max-line-length = 120
 
 [tool:pytest]
 asyncio_mode = auto

--- a/test/test_responsefetcher.py
+++ b/test/test_responsefetcher.py
@@ -1,3 +1,5 @@
+from functools import partial
+from typing import Any, Callable, Dict, List
 import unittest
 from aiounittest import AsyncTestCase
 from asyncio import TimeoutError
@@ -7,7 +9,7 @@ from aiohttp import (
 )
 from aiohttp_retry import RetryClient
 from unittest.mock import Mock, patch
-from aioresponses import aioresponses
+from aioresponses import aioresponses, CallbackResult
 from deadseeker.common import SeekerConfig
 from deadseeker.timer import Timer
 from deadseeker.responsefetcher import (
@@ -41,6 +43,15 @@ TYPE_JSON = 'application/json'
 TEST_EXPECTED_ELAPSED = 4000.0
 
 
+def _get_callback(get_calls: List[Dict[str, Any]], body: str, content_type: str, *args, **kwargs):
+    # first arugment to the callback is always the url
+    kwargs["url"] = str(args[0])
+    for idx, arg in enumerate(args[1:]):
+        kwargs[f"args[{idx}]"] = str(arg)
+    get_calls.append(kwargs)
+    return CallbackResult(body=body, content_type=content_type)
+
+
 class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
 
     def setUp(self):
@@ -57,7 +68,7 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     @aioresponses()
     async def test_if_same_site_and_html(self,  m):
         self._prep_request(m, TEST_HOME_URL, content_type=TYPE_HTML)
-        # We use the RetryClient() as a session instance here
+        # We use the RetryClient as a session instance here which also works with aioresponses Mocks
         # One could also use a aiohttp ClientSession instance
         async with RetryClient() as session:
             response = await self.testobj.fetch_response(
@@ -72,29 +83,38 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
     @aioresponses()
     async def test_if_same_site_and_html_head_not_supported(self,  m):
         exception = ClientResponseError(None, None, status=405)
+        get_calls: List[Dict[str, Any]] = []
+
         self._prep_request(
             m,
             TEST_HOME_URL,
             headexception=exception,
-            content_type=TYPE_HTML)
+            content_type=TYPE_HTML,
+            get_callback=partial(_get_callback, get_calls, TEST_BODY, TYPE_HTML))
+
         async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
             self.assertIs(self.urltarget, response.urltarget)
             self.assertEqual(200, response.status)
-            self.assertEqual(TEST_BODY, response.html)
             self.assertIsNone(response.error)
             self.assertEqual(TEST_EXPECTED_ELAPSED, response.elapsed)
+            self.assertNotEqual([], get_calls)
+            self.assertEqual(1, len(get_calls))
+            self.assertEqual(TEST_BODY, response.html)
 
     # Test for ScholliYT/Broken-Links-Crawler-Action#8
     @aioresponses()
     async def test_if_same_site_and_not_html_head_not_supported(self,  m):
         exception = ClientResponseError(None, None, status=405)
+        get_calls: List[Dict[str, Any]] = []
+
         self._prep_request(
             m,
             TEST_HOME_URL,
             headexception=exception,
-            content_type=TYPE_JSON)
+            get_callback=partial(_get_callback, get_calls, TEST_BODY, TYPE_JSON))
+
         async with RetryClient() as session:
             response = await self.testobj.fetch_response(
                     session, self.urltarget)
@@ -103,6 +123,29 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             self.assertIsNone(response.html)
             self.assertIsNone(response.error)
             self.assertEqual(TEST_EXPECTED_ELAPSED, response.elapsed)
+            self.assertNotEqual([], get_calls)
+            self.assertEqual(1, len(get_calls))
+
+    # Test for ScholliYT/Broken-Links-Crawler-Action#8
+    @aioresponses()
+    async def test_if_same_site_and_not_html_head_supported(self,  m):
+        get_calls: List[Dict[str, Any]] = []
+
+        self._prep_request(
+            m,
+            TEST_HOME_URL,
+            content_type=TYPE_JSON,
+            get_callback=partial(_get_callback, get_calls, TEST_BODY, TYPE_JSON))
+
+        async with RetryClient() as session:
+            response = await self.testobj.fetch_response(
+                    session, self.urltarget)
+            self.assertIs(self.urltarget, response.urltarget)
+            self.assertEqual(200, response.status)
+            self.assertIsNone(response.html)
+            self.assertIsNone(response.error)
+            self.assertEqual(TEST_EXPECTED_ELAPSED, response.elapsed)
+            self.assertEqual([], get_calls)
 
     # Test for ScholliYT/Broken-Links-Crawler-Action#8
     @aioresponses()
@@ -208,7 +251,9 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
             mockresponses,
             url: str,
             content_type: str = None,
-            headexception: Exception = None):
+            headexception: Exception = None,
+            get_body=TEST_BODY,
+            get_callback: Callable[..., CallbackResult] = None):
         self.urltarget.url = url
         mockresponses.head(
             url,
@@ -218,7 +263,8 @@ class TestHeadThenGetIfHtmlResponseFetcher(AsyncTestCase):
         mockresponses.get(
             url,
             content_type=content_type,
-            body=TEST_BODY
+            body=get_body,
+            callback=get_callback  # setting the callback to a callable function overwrites the body argument
         )
 
 


### PR DESCRIPTION
The HeadThenGetIfHtmlResponseFetcher performed a GET request even if the HEAD already returned a non HTML content type.
Additionally, the exceptions of the GET request were also catched leading to a possible double GET request if the first request returned a 405 status code.