### PR TITLE
Display page containing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 # Broken-Links-Crawler-Action
 This action checks all links on a website. It will detect broken links i.e. links that return HTTP Code 403, 404...
 Check the logs to see which links are broken and consequently cause this action to fail. 
+In addition to the actual broken url, the navigation path to that location is also displayed.
 
 Based on this work: https://github.com/healeycodes/Broken-Link-Crawler  
 **Demo: https://github.com/ScholliYT/devportfolio/actions?query=workflow%3A%22Site+Reliability%22**
+
 ## Inputs
 
 ### `website_url`

--- a/deadseeker/common.py
+++ b/deadseeker/common.py
@@ -37,6 +37,20 @@ class UrlTarget():
         self.home = home
         self.url = url
         self.depth = depth
+        # We don't know the parent element (yet)
+        self.parent: Optional[UrlTarget] = None
+
+    def child(self, url: str) -> 'UrlTarget':
+        child = UrlTarget(self.home, url, self.depth - 1)
+        # We store the parent Url from where we found this one in the parent
+        child.parent = self
+        return child
+
+    def parent_urls(self) -> List[str]:
+        if self.parent:
+            return self.parent.parent_urls() + [self.parent.url]
+        else:
+            return []
 
 
 class UrlFetchResponse():

--- a/deadseeker/deadseeker.py
+++ b/deadseeker/deadseeker.py
@@ -95,8 +95,7 @@ class DeadSeeker:
                 newurl = urljoin(base, newurl)
                 if newurl not in visited:
                     visited.add(newurl)
-                    targets.appendleft(
-                        UrlTarget(resp.urltarget.home, newurl, depth - 1))
+                    targets.appendleft(resp.urltarget.child(newurl))
 
     def seek(
             self,

--- a/deadseeker/loggingresponsehandler.py
+++ b/deadseeker/loggingresponsehandler.py
@@ -13,11 +13,17 @@ class LoggingUrlFetchResponseHandler(UrlFetchResponseHandler):
         error = resp.error
         if error:
             errortype = type(error).__name__
+
+            navigation_path = " -> ".join(resp.urltarget.parent_urls())
+            navigation_path_msg = ""
+            if navigation_path:
+                navigation_path_msg = ". Found by navigating through: " + navigation_path + "."
+
             if status:
-                logger.error(f'::error ::{errortype}: {status} - {url}')
+                logger.error(f'::error ::{errortype}: {status} - {url}{navigation_path_msg}')
             else:
                 logger.error(
-                    f'::error ::{errortype}: {str(error)} - {url}')
+                    f'::error ::{errortype}: {str(error)} - {url}{navigation_path_msg}')
             logger.debug("The following exception occured", exc_info=error)
         else:
             logger.info(f'{status} - {url} - {elapsedstr}')

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -90,5 +90,30 @@ class TestUrlFetchResponse(unittest.TestCase):
         self.assertIsNone(self.testobj.html)
 
 
+class TestUrlTarget(unittest.TestCase):
+
+    def setUp(self):
+        self.testobj = UrlTarget("https://example.com", "https://example.com", 5)
+
+    def test_child_has_parent(self):
+        child = self.testobj.child("https://test.com")
+        self.assertEqual(self.testobj.home, child.home)
+        self.assertEqual(self.testobj.depth - 1, child.depth)
+        self.assertIsNone(self.testobj.parent)
+        self.assertEqual(self.testobj, child.parent)
+        self.assertEqual("https://test.com", child.url)
+
+    def test_parent_urls_generates_only_urls_for_parents(self):
+        child1 = self.testobj.child("https://example.com/1")
+        child2 = child1.child("https://example.com/2")
+
+        output = child2.parent_urls()
+        expected_urls = [
+            "https://example.com",
+            "https://example.com/1"
+        ]
+        self.assertEqual(expected_urls, output)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -105,8 +105,9 @@ class TestIntegration(unittest.TestCase):
                 patch.object(self.logger, 'info') as info_mock:
             run_action()
             expected_errors = [
-                f'::error ::ClientResponseError: 500 - {self.url}/page4.html',
-                f'::error ::ClientResponseError: 404 - {self.url}/page3.html'
+                f'::error ::ClientResponseError: 500 - {self.url}/page4.html. Found by navigating through: {self.url}.',
+                f'::error ::ClientResponseError: 404 - {self.url}/page3.html.' +
+                f' Found by navigating through: {self.url} -> {self.url}/page1.html -> {self.url}/page2.html.'
             ]
             actual_errors: List[str] = []
             for call in error_mock.call_args_list:

--- a/test/test_loggingresponsehandler.py
+++ b/test/test_loggingresponsehandler.py
@@ -6,6 +6,7 @@ from aiohttp import ClientError
 import logging
 
 TEST_URL = 'http://testing.test.com/'
+TEST_SUBPAGE_URL = 'http://subpage.testing.test.com/'
 
 
 class TestLoggingResponseHandler(unittest.TestCase):
@@ -13,8 +14,14 @@ class TestLoggingResponseHandler(unittest.TestCase):
     def setUp(self):
         self.testobj = LoggingUrlFetchResponseHandler()
         target = UrlTarget(TEST_URL, TEST_URL, 0)
+
         self.resp = UrlFetchResponse(target)
         self.resp.elapsed = 1234.1234
+
+        subpage_target = target.child(TEST_SUBPAGE_URL).child(TEST_SUBPAGE_URL + 'page1')
+        self.subpage_response = UrlFetchResponse(subpage_target)
+        self.subpage_response.elapsed = 12.12
+
         self.logger = logging.getLogger('deadseeker.loggingresponsehandler')
 
     def test_info_logs_when_success(self):
@@ -39,6 +46,23 @@ class TestLoggingResponseHandler(unittest.TestCase):
             error_mock.assert_called_with(expected_error)
             debug_mock.assert_called_with(expected_debug,
                                           exc_info=self.resp.error)
+            info_mock.assert_not_called()
+
+    def test_error_logs_when_responseerror_including_navigationpath(self):
+        self.subpage_response.status = 400
+        self.subpage_response.error = ClientError()
+        with patch.object(self.logger, 'error') as error_mock,\
+                patch.object(self.logger, 'info') as info_mock,\
+                patch.object(self.logger, 'debug') as debug_mock:
+            self.testobj.handle_response(self.subpage_response)
+            expected_error = '::error ::ClientError: 400' +\
+                ' - http://subpage.testing.test.com/page1' +\
+                '. Found by navigating through: http://testing.test.com/ ' +\
+                '-> http://subpage.testing.test.com/.'
+            expected_debug = 'The following exception occured'
+            error_mock.assert_called_with(expected_error)
+            debug_mock.assert_called_with(expected_debug,
+                                          exc_info=self.subpage_response.error)
             info_mock.assert_not_called()
 
     def test_error_logs_when_no_status_error(self):


### PR DESCRIPTION
This is a PR to fix #13.

As of now the complete navigation path to find a broken/dead link will be logged.

The Log looks like this: 
```
::error ::ClientResponseError: 404 - https://example.com/page3.html. Found by navigating through: https://example.com -> https://example.com/page1.html -> https://example.com/page2.html.
```

This can be read as the crawler going to `https://example.com` and from there to `/page1.html`, then `/page2.html` and on that page it found a broken link to `/page3.html`.