### PR TITLE
Fix http redirects

### DIFF
--- a/deadseeker/responsefetcher.py
+++ b/deadseeker/responsefetcher.py
@@ -68,6 +68,10 @@ class AbstractResponseFetcher(ResponseFetcher, ABC):
         async with session.get(url) as response:
             timer.stop()
             resp.status = response.status
+            # Because of redirects the url might have changed. Update it here.
+            # This fixes https://github.com/ScholliYT/Broken-Links-Crawler-Action/issues/39
+            urltarget.url = str(response.real_url)
+
             if has_html(response) and is_onsite(urltarget):
                 resp.html = await response.text()
 

--- a/test/mock_server/index.html
+++ b/test/mock_server/index.html
@@ -11,5 +11,9 @@
   <a href="/page1.html">To Page 1</a>
   <a href="/page4.html">To Page 4</a>
   <a href="/subpages/subpage1.html">To Subpage 1</a>
+  <!-- This link redirects to /subpages/subsubpages/ see https://github.com/ScholliYT/Broken-Links-Crawler-Action/issues/39 -->
+  <a href="/subpages/subsubpages">To Subpage index</a> 
+  <!-- This link has no redirect see https://github.com/ScholliYT/Broken-Links-Crawler-Action/issues/39 -->
+  <a href="/subpages/subsubpages/">To Subpage index /</a>
 </body>
 </html>

--- a/test/mock_server/subpages/redirect/redirect.html
+++ b/test/mock_server/subpages/redirect/redirect.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>Redirect</title>
+</head>
+<body>
+  <h1>Redirect</h1>
+  <a href="/page3.html">To Page 3</a>
+  <a href="/page1.html">To Page 1</a>
+</body>
+</html>

--- a/test/mock_server/subpages/subsubpages/index.html
+++ b/test/mock_server/subpages/subsubpages/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>Subpage index</title>
+</head>
+<body>
+  <h1>Subpage index</h1>
+  <a href="/page2.html">To Page 2</a>
+  <a href="/subpages/redirect/redirect.html">To redirected page via absolute link</a>
+  <a href="../redirect/redirect.html">To redirected page via relative link</a>
+</body>
+</html>


### PR DESCRIPTION
This fixes the HTTP redirect errors from #39 

This might also fix #56 

This PR Adds a fix for to update the URL after following all redirects. It uses Pyhton urllib's `real_url`. The changes are tested by a dedicated testcase in the integration test suite.

This fix is not optimal as it causes duplicate requests to the same URL.
Additionally the path of the redirect is not traceable.